### PR TITLE
Refactoring install commands into install phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,14 @@ language: node_js
 node_js:
     - '0.12'
 notifications:
-    irc: 'irc.freenode.org#tastejs'
+  irc: 'irc.freenode.org#tastejs'
 addons:
-    sauce_connect: true
+  sauce_connect: true
 env:
     # add in tokens for sauce labs
-    global:
-        - secure: gd7Y1sZyUc4+eck+c4cZ19WdVkmvvfE16fegUMZ9/BMRVYaaEfLZ/805+mOPccAebu5nuGKX0dAjXBwDGcAk2T9YvXpgl8GHu5sAHT3ax0XTibwW7Je2ayf8dJqTO9eRelY616v2mYUlj9QMmbWCB2zESsscY3hi2DQAPeueMdo=
-        - secure: av1hgfvD9UpQr59Q2qcyC0WmiUvRivJHzdcrwj3uYiIJLxxpXv00EC4PzqMZAVREOaQEK1s9FwFVSYn8FbvtvWp5TnWNvSXUXCSjc+I0MYhxbtvcAuKlDzayHSfp17bt0BY3pxB/1BdwMdPwDYumEULphKOmsLr4ocsJCfng2Ds=
+  global:
+      - secure: gd7Y1sZyUc4+eck+c4cZ19WdVkmvvfE16fegUMZ9/BMRVYaaEfLZ/805+mOPccAebu5nuGKX0dAjXBwDGcAk2T9YvXpgl8GHu5sAHT3ax0XTibwW7Je2ayf8dJqTO9eRelY616v2mYUlj9QMmbWCB2zESsscY3hi2DQAPeueMdo=
+      - secure: av1hgfvD9UpQr59Q2qcyC0WmiUvRivJHzdcrwj3uYiIJLxxpXv00EC4PzqMZAVREOaQEK1s9FwFVSYn8FbvtvWp5TnWNvSXUXCSjc+I0MYhxbtvcAuKlDzayHSfp17bt0BY3pxB/1BdwMdPwDYumEULphKOmsLr4ocsJCfng2Ds=
         # GH_OAUTH_TOKEN is the oauth token generated as described at
         # https://help.github.com/articles/creating-an-oauth-token-for-command-line-use
         #
@@ -26,16 +26,18 @@ env:
         # travis encrypt GH_OAUTH_TOKEN=XXXXXXXXXXXXXXX
         #
         # User specific env variables
-        - secure: 'fHgfjMpYuliwMr2QLnjYZExIViNrxprf9dhXRBLZ6P9Hz7P6m1BMYrI/xEG8X+fFbCi0+n3AXh8SEMHi9ou/Pty/cx12z4w/z3B2BHMxh4XBwpZHs+AB4IXkLiwwWoP4QFy4vTipgYnMDMq9CRhlRbhZEpenQBmaTEc472By1uM='
-        - GH_OWNER: tastejs
-        - GH_PROJECT_NAME: todomvc
+      - secure: 'fHgfjMpYuliwMr2QLnjYZExIViNrxprf9dhXRBLZ6P9Hz7P6m1BMYrI/xEG8X+fFbCi0+n3AXh8SEMHi9ou/Pty/cx12z4w/z3B2BHMxh4XBwpZHs+AB4IXkLiwwWoP4QFy4vTipgYnMDMq9CRhlRbhZEpenQBmaTEc472By1uM='
+      - GH_OWNER: tastejs
+      - GH_PROJECT_NAME: todomvc
 
-before_script:
+install:
     # install dependencies
+    - npm install
     - npm install -g gulp
-    - python -m SimpleHTTPServer > /dev/null 2>&1 &
-    - sleep 2
+before_script:
+      - python -m SimpleHTTPServer > /dev/null 2>&1 &
+      - sleep 2
 script:
     # We want to gate on passing tests and a successful build
-    - gulp
-    - ./test-runner.sh
+      - gulp
+      - ./test-runner.sh


### PR DESCRIPTION
-------------------------------

Having install commands in other phases violates the semantics of the `.travis.yml` configuration. So we have refactored them into the `install` phase.

If the `install` phase is not defined in the `.travis.yml`,  Travis CI runs `npm install` for Node.js projects by default, as explained in the Travis CI docs [here](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Travis-CI-uses-npm). To preserve that original behaviour after refactoring, we have added the `npm install` command as well.

-------------------------------

**Note:** This pull request was generated by an automated tool developed by [The Software REBELs](http://rebels.ece.mcgill.ca/) (a.k.a., the Software Repository Excavation and Build Engineering Labs) of McGill University, Canada. It is part of a research project by [Keheliya Gallaba](http://keheliya.github.io/) under the supervision of [Dr.Shane McIntosh](http://shanemcintosh.org). If you have any questions or feedback about this tool, please feel free to contact the author (keheliya.gallaba@mail.mcgill.ca).